### PR TITLE
Modify filter: work with null vals

### DIFF
--- a/src/solo.table.js
+++ b/src/solo.table.js
@@ -401,6 +401,9 @@ angular.module("solo.table", [])
 			{
 				var compare = function(val, search)
 				{
+                    // null hasn't method toString()
+                    if ( val == null )
+                        return false;
 					return val.toString().toLowerCase().indexOf(search) !== -1;
 				};
 


### PR DESCRIPTION
Если применить фильтрацию к колонке, которая содержит null значения, то произойдет ошибка
TypeError: Cannot call method 'toString' of null
at compare (http://site.com/static/js/lib/solo.table.js:407:17)
Добавил проверку в соответствующую функцию.
